### PR TITLE
Fix bug in tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -133,5 +133,5 @@ def test_conjecture():
   print(language.program_string(theory))
   for i in range(10):
     theory=conjecture.vary([theory], 0, [], steps=1)
-    print(f"Theory after {i+1} stages of variation:")
+    print("Theory after {i+1} stages of variation:")
     print(language.program_string(theory))


### PR DESCRIPTION
I know next to nothing about Python, but I *think* this prevented me from running the tests.

I got:

```bash
  File "tests.py", line 136
    print(f"Theory after {i+1} stages of variation:")
                                                   ^
SyntaxError: invalid syntax
```

And, even the the caret points at the end of the line, I'm guessing it's because of the `f` at the beginning.